### PR TITLE
auto adjust scale of y2 axis on the top graph

### DIFF
--- a/generate.gnuplot
+++ b/generate.gnuplot
@@ -98,7 +98,7 @@ set ylabel "Number of users" textcolor rgb "#93ddff" offset 1,0,0
 
 # Set Y2 axis
 set y2r [0:uc_derivative_high * 2]
-set y2tics 10 nomirror
+set y2tics floor(uc_derivative_high / 3) nomirror
 set y2label 'Hourly increase' textcolor rgb "#7ae9d8" 
 
 # Set X axis


### PR DESCRIPTION
Resolves: #2 
The distance between tics on the y2 axis was previously hard-coded to 10.  After a certain point, these values became very hard to read.  I have changed it so that there will always be ~6 evenly-spaced tics.

(Note: I have not yet had a chance to gather much data in mastostats.csv.  Ideally, this should be tested when there are large values on the y2 axis.)